### PR TITLE
record type for window options

### DIFF
--- a/src/Electron/BrowserWindow.js
+++ b/src/Electron/BrowserWindow.js
@@ -4,13 +4,9 @@
 
 const BrowserWindow = require('electron').BrowserWindow;
 
-function browserWindowOptionsFrom(options) {
-  return {}; // TODO
-}
-
 exports.newBrowserWindow = function(options) {
   return function() {
-    return new BrowserWindow(browserWindowOptionsFrom(options));
+    return new BrowserWindow(options);
   };
 }
 

--- a/src/Electron/BrowserWindow.purs
+++ b/src/Electron/BrowserWindow.purs
@@ -1,6 +1,5 @@
 module Electron.BrowserWindow
-  ( BrowserWindowOption(..)
-  , BrowserWindowOptions(..)
+  ( BrowserWindowOptions(..)
   , BrowserWindow()
   , newBrowserWindow
   , onClose
@@ -14,11 +13,11 @@ import Control.Monad.Eff.Unsafe
 
 import Electron.Eff
 
-data BrowserWindowOption
-  = Width Int
-  | Height Int
-
-type BrowserWindowOptions = Array BrowserWindowOption
+type BrowserWindowOptions =
+  { width :: Int
+  , height :: Int
+  , show :: Boolean
+  }
 
 foreign import data BrowserWindow :: *
 


### PR DESCRIPTION
For more than a few possible options, the list approach probably is better, but for BrowserWindow options, I think a plain record is ok for the start.
