### PR TITLE
Added onAllWindowsClosed callback

### DIFF
--- a/src/Electron/App.js
+++ b/src/Electron/App.js
@@ -26,6 +26,14 @@ exports.onReady = function(callback) {
   };
 }
 
+exports.onAllWindowsClosed = function(callback) {
+  return function() {
+    return app.on('window-all-closed', function() {
+      callback();
+    });
+  };
+}
+
 function camelCaseConstructorNameFor(value) {
   const ctorName = value.constructor.name;
   return ctorName[0].toLowerCase() + ctorName.substring(1);

--- a/src/Electron/App.purs
+++ b/src/Electron/App.purs
@@ -3,6 +3,7 @@ module Electron.App
   , getPath
   , Path(..)
   , onReady
+  , onAllWindowsClosed
   , quit
   ) where
 
@@ -26,5 +27,9 @@ data Path
 -- |
 -- | [Official Electron documentation](http://electron.atom.io/docs/all/#event-39-ready-39)
 foreign import onReady :: forall eff
+   . Eff (electron :: ELECTRON | eff) Unit
+  -> Eff (electron :: ELECTRON | eff) Unit
+
+foreign import onAllWindowsClosed :: forall eff
    . Eff (electron :: ELECTRON | eff) Unit
   -> Eff (electron :: ELECTRON | eff) Unit


### PR DESCRIPTION
when I used the sample application I got an error when the onclose handler on the browserWindow was called. This fixed it for me with version 0.37.5 of electron.
