### PR TITLE
flip openDevTools

### DIFF
--- a/src/Electron/BrowserWindow.js
+++ b/src/Electron/BrowserWindow.js
@@ -34,8 +34,8 @@ exports.webContents = function(browserWindow) {
   };
 }
 
-exports.openDevToolsImpl = function(webContents) {
-  return function(options) {
+exports.openDevToolsImpl = function(options) {
+  return function(webContents) {
     return function() {
       webContents.openDevTools(options);
       return {};

--- a/src/Electron/BrowserWindow.purs
+++ b/src/Electron/BrowserWindow.purs
@@ -72,14 +72,14 @@ foreign import webContents :: forall eff
 -- |
 -- | [Official Electron documentation](http://electron.atom.io/docs/all/#webcontents-opendevtools-options)
 openDevTools :: forall eff
-   . WebContents
-  -> DevToolOptions
+   . DevToolOptions
+  -> WebContents
   -> Eff (electron :: ELECTRON | eff) Unit
-openDevTools wc = encodeOptions >>> openDevToolsImpl wc
+openDevTools opts wc = openDevToolsImpl (encodeOptions opts) wc
 
 foreign import openDevToolsImpl :: forall eff
-   . WebContents
-  -> Json
+   . Json
+  -> WebContents
   -> Eff (electron :: ELECTRON | eff) Unit
 
 data DevToolOption


### PR DESCRIPTION
I think opts may comes first.

it makes natural to write

webContents window >>= opendevTools []
